### PR TITLE
Fix html comment

### DIFF
--- a/src/StatiCache.php
+++ b/src/StatiCache.php
@@ -33,7 +33,7 @@ class StatiCache extends FileCache
 
     public function set(string $key, $value, int $minutes = 0): bool
     {
-        return F::write($this->file($key), $value['html'] . '<-- static -->');
+        return F::write($this->file($key), $value['html'] . '<!-- static -->');
     }
 
 }


### PR DESCRIPTION
The plugin attaches the string `<-- static -->` to the HTML. I guess this should be an HTML comment. Otherwise, the string will be shown on the website.