### PR TITLE
Fix compatibility with Kirby 3.8

### DIFF
--- a/src/StatiCache.php
+++ b/src/StatiCache.php
@@ -26,9 +26,10 @@ class StatiCache extends FileCache
         return $this->root . '/' . $path . '/' . $name . '/index.' . $extension;
     }
 
-    public function retrieve(string $key)
+    public function retrieve(string $key): Value|null
     {
-        return F::read($this->file($key));
+        $value = F::read($this->file($key));
+        return $value ? new Value($value) : null;
     }
 
     public function set(string $key, $value, int $minutes = 0): bool


### PR DESCRIPTION
@lukasbestle tackling this bug in our own plugin, the Value object handling seems pretty harsh here (like too much overhead, the former implementation of just a string seemed fine). Can we easy this again somehow?

Also makes me think that I am not too much in love with https://github.com/getkirby/kirby/pull/4263 - I think many developers would prefer to handle the raw value for their cache and not have to deal with our wrapper Value object.