### PR TITLE
Add compression option for pre-compressed cache files

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,90 @@ Replace the last six lines of the loader function with this code:
   die($body);
 ```
 
+### Compression
+
+Staticache can write pre-compressed copies of cached files alongside the originals. This lets your web server serve them directly without runtime compression overhead (e.g. `mod_deflate`).
+
+Enable compression with the `compression` option:
+
+```php
+// /site/config/config.php
+
+return [
+  ‘cache’ => [
+    ‘pages’ => [
+      ‘active’      => true,
+      ‘type’        => ‘static’,
+
+      // gzip with default compression level (6)
+      ‘compression’ => [‘gzip’],
+
+      // OR with explicit compression level (0-9)
+      ‘compression’ => [‘gzip’ => 9]
+    ]
+  ]
+];
+```
+
+For each cached file (e.g. `index.html`), a compressed copy (e.g. `index.html.gz`) will be written next to it. The compressed files are automatically cleaned up when the cache is purged.
+
+You will need to configure your web server to prefer the pre-compressed files:
+
+**Apache:**
+
+Add the following to your `.htaccess` file. This tells Apache to serve the `.gz` file when the client supports gzip and a pre-compressed file exists:
+
+```
+# Serve pre-compressed gzip files if they exist
+<IfModule mod_headers.c>
+  RewriteCond %{HTTP:Accept-Encoding} gzip
+  RewriteCond %{REQUEST_URI} \.html$
+  RewriteCond %{REQUEST_FILENAME}.gz -f
+  RewriteRule ^(.+)$ $1.gz [L]
+
+  # Serve correct content type and encoding
+  <FilesMatch "\.html\.gz$">
+    Header set Content-Encoding gzip
+    Header set Content-Type "text/html; charset=UTF-8"
+    # Prevent double compression
+    SetEnv no-gzip 1
+  </FilesMatch>
+</IfModule>
+```
+
+When using Staticache’s rewrite rules, you need to add gzip-aware variants before them:
+
+```
+# Serve pre-compressed static cache files
+RewriteCond %{HTTP:Accept-Encoding} gzip
+RewriteCond %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI}/index.html.gz -f
+RewriteRule ^(.*) %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI}/index.html.gz [END,E=CONTENT_TYPE:text/html,E=CONTENT_ENCODING:gzip]
+
+# Fall back to uncompressed static cache
+RewriteCond %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI}/index.html -f
+RewriteRule ^(.*) %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI}/index.html [END]
+
+RewriteCond %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI} -f
+RewriteRule ^(.*) %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI} [END]
+
+<IfModule mod_headers.c>
+  Header set Content-Encoding gzip env=CONTENT_ENCODING
+  Header set Content-Type "text/html; charset=UTF-8" env=CONTENT_TYPE
+  SetEnvIf Request_URI "\.gz$" no-gzip 1
+</IfModule>
+```
+
+**nginx:**
+
+```
+location / {
+  gzip_static on;
+  try_files $uri $uri/ /site/cache/$server_addr/pages/$uri/index.html /site/cache/$server_addr/pages/$uri /index.php?$query_string;
+}
+```
+
+nginx’s `gzip_static` module will automatically prefer `.gz` files when available and the client supports gzip.
+
 ## What’s Kirby?
 - **[getkirby.com](https://getkirby.com)** – Get to know the CMS.
 - **[Try it](https://getkirby.com/try)** – Take a test ride with our online demo. Or download one of our kits to get started.

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Replace the last six lines of the loader function with this code:
 
 ### Compression
 
-Staticache can write pre-compressed copies of cached files alongside the originals. This lets your web server serve them directly without runtime compression overhead (e.g. `mod_deflate`).
+Staticache can write pre-compressed copies of cached files alongside the originals. This lets your web server serve them directly without runtime compression overhead.
 
 Enable compression with the `compression` option:
 
@@ -324,16 +324,16 @@ Enable compression with the `compression` option:
 // /site/config/config.php
 
 return [
-  ‘cache’ => [
-    ‘pages’ => [
-      ‘active’      => true,
-      ‘type’        => ‘static’,
+  'cache' => [
+    'pages' => [
+      'active'      => true,
+      'type'        => 'static',
 
       // gzip with default compression level (6)
-      ‘compression’ => [‘gzip’],
+      'compression' => ['gzip'],
 
       // OR with explicit compression level (0-9)
-      ‘compression’ => [‘gzip’ => 9]
+      'compression' => ['gzip' => 9]
     ]
   ]
 ];
@@ -345,33 +345,13 @@ You will need to configure your web server to prefer the pre-compressed files:
 
 **Apache:**
 
-Add the following to your `.htaccess` file. This tells Apache to serve the `.gz` file when the client supports gzip and a pre-compressed file exists:
-
-```
-# Serve pre-compressed gzip files if they exist
-<IfModule mod_headers.c>
-  RewriteCond %{HTTP:Accept-Encoding} gzip
-  RewriteCond %{REQUEST_URI} \.html$
-  RewriteCond %{REQUEST_FILENAME}.gz -f
-  RewriteRule ^(.+)$ $1.gz [L]
-
-  # Serve correct content type and encoding
-  <FilesMatch "\.html\.gz$">
-    Header set Content-Encoding gzip
-    Header set Content-Type "text/html; charset=UTF-8"
-    # Prevent double compression
-    SetEnv no-gzip 1
-  </FilesMatch>
-</IfModule>
-```
-
-When using Staticache’s rewrite rules, you need to add gzip-aware variants before them:
+Replace the Staticache rewrite rules in your `.htaccess` (see above) with gzip-aware variants[^1](https://httpd.apache.org/docs/2.4/mod/mod_deflate.html#precompressed):
 
 ```
 # Serve pre-compressed static cache files
 RewriteCond %{HTTP:Accept-Encoding} gzip
 RewriteCond %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI}/index.html.gz -f
-RewriteRule ^(.*) %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI}/index.html.gz [END,E=CONTENT_TYPE:text/html,E=CONTENT_ENCODING:gzip]
+RewriteRule ^(.*) %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI}/index.html.gz [END]
 
 # Fall back to uncompressed static cache
 RewriteCond %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI}/index.html -f
@@ -380,12 +360,35 @@ RewriteRule ^(.*) %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI
 RewriteCond %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI} -f
 RewriteRule ^(.*) %{DOCUMENT_ROOT}/site/cache/%{SERVER_NAME}/pages/%{REQUEST_URI} [END]
 
+# Serve correct content type/encoding and prevent double compression
+RewriteRule \.html\.gz$ - [T=text/html,E=no-gzip:1]
+
 <IfModule mod_headers.c>
-  Header set Content-Encoding gzip env=CONTENT_ENCODING
-  Header set Content-Type "text/html; charset=UTF-8" env=CONTENT_TYPE
-  SetEnvIf Request_URI "\.gz$" no-gzip 1
+  <FilesMatch "\.gz$">
+    Header append Content-Encoding gzip
+    Header append Vary Accept-Encoding
+  </FilesMatch>
 </IfModule>
 ```
+
+**Caddy:**
+
+Add `precompressed` to your `file_server` directive[^2](https://caddyserver.com/docs/caddyfile/directives/file_server). Without arguments, it checks for brotli, zstd, and gzip sidecar files (in that order):
+
+```
+example.com
+
+root * /path/to/your/site
+
+file_server {
+  precompressed
+}
+php_fastcgi unix//var/run/php-fpm.sock {
+  try_files {path} site/cache/{host}/pages/{path}/index.html site/cache/{host}/pages/{path} index.php
+}
+```
+
+Caddy will automatically serve pre-compressed files with the correct `Content-Encoding` header.
 
 **nginx:**
 
@@ -396,9 +399,9 @@ location / {
 }
 ```
 
-nginx’s `gzip_static` module will automatically prefer `.gz` files when available and the client supports gzip.
+nginx's `gzip_static` module will automatically prefer `.gz` files when available and the client supports gzip[^3](https://nginx.org/en/docs/http/ngx_http_gzip_static_module.html).
 
-## What’s Kirby?
+## What's Kirby?
 - **[getkirby.com](https://getkirby.com)** – Get to know the CMS.
 - **[Try it](https://getkirby.com/try)** – Take a test ride with our online demo. Or download one of our kits to get started.
 - **[Documentation](https://getkirby.com/docs/guide)** – Read the official guide, reference, and cookbook recipes.

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ You will need to configure your web server to prefer the pre-compressed files:
 
 **Apache:**
 
-Replace the Staticache rewrite rules in your `.htaccess` (see above) with gzip-aware variants[^1](https://httpd.apache.org/docs/2.4/mod/mod_deflate.html#precompressed):
+Replace the Staticache rewrite rules in your `.htaccess` (see above) with gzip-aware variants[^1]:
 
 ```
 # Serve pre-compressed static cache files
@@ -373,7 +373,7 @@ RewriteRule \.html\.gz$ - [T=text/html,E=no-gzip:1]
 
 **Caddy:**
 
-Add `precompressed` to your `file_server` directive[^2](https://caddyserver.com/docs/caddyfile/directives/file_server). Without arguments, it checks for brotli, zstd, and gzip sidecar files (in that order):
+Add `precompressed` to your `file_server` directive[^2]. Without arguments, it checks for brotli, zstd, and gzip sidecar files (in that order):
 
 ```
 example.com
@@ -399,7 +399,7 @@ location / {
 }
 ```
 
-nginx's `gzip_static` module will automatically prefer `.gz` files when available and the client supports gzip[^3](https://nginx.org/en/docs/http/ngx_http_gzip_static_module.html).
+nginx's `gzip_static` module will automatically prefer `.gz` files when available and the client supports gzip[^3].
 
 ## What's Kirby?
 - **[getkirby.com](https://getkirby.com)** – Get to know the CMS.
@@ -417,3 +417,7 @@ nginx's `gzip_static` module will automatically prefer `.gz` files when availabl
 ## License
 
 [MIT](./LICENSE) License © 2022 [Bastian Allgeier](https://getkirby.com)
+
+[^1]: https://httpd.apache.org/docs/2.4/mod/mod_deflate.html#precompressed
+[^2]: https://caddyserver.com/docs/caddyfile/directives/file_server
+[^3]: https://nginx.org/en/docs/http/ngx_http_gzip_static_module.html

--- a/index.php
+++ b/index.php
@@ -1,7 +1,11 @@
 <?php
 
 load([
-	'Kirby\Cache\StatiCache' => __DIR__ . '/src/StatiCache.php'
+	'Kirby\Cache\StatiCache' => __DIR__ . '/src/StatiCache.php',
+	'Kirby\Cache\Compression\BrotliEncoder' => __DIR__ . '/src/Compression/BrotliEncoder.php',
+	'Kirby\Cache\Compression\CompressionEncoder' => __DIR__ . '/src/Compression/CompressionEncoder.php',
+	'Kirby\Cache\Compression\GzipEncoder' => __DIR__ . '/src/Compression/GzipEncoder.php',
+	'Kirby\Cache\Compression\ZstdEncoder' => __DIR__ . '/src/Compression/ZstdEncoder.php'
 ]);
 
 Kirby::plugin('getkirby/staticache', [

--- a/src/Compression/BrotliEncoder.php
+++ b/src/Compression/BrotliEncoder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Kirby\Cache\Compression;
+
+/**
+ * Brotli compression encoder
+ *
+ * Requires the `brotli` PHP extension to be loaded.
+ *
+ * @package   Kirby Staticache
+ * @author    Tobias Möritz
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class BrotliEncoder implements CompressionEncoder
+{
+	public function encoding(): string
+	{
+		return 'br';
+	}
+
+	public function extension(): string
+	{
+		return 'br';
+	}
+
+	public function defaultLevel(): int
+	{
+		return 4;
+	}
+
+	public function encode(string $content, int $level): string|false
+	{
+		return brotli_compress($content, $level);
+	}
+}

--- a/src/Compression/BrotliEncoder.php
+++ b/src/Compression/BrotliEncoder.php
@@ -27,7 +27,7 @@ class BrotliEncoder implements CompressionEncoder
 
 	public function defaultLevel(): int
 	{
-		return 4;
+		return BROTLI_COMPRESS_LEVEL_DEFAULT;
 	}
 
 	public function encode(string $content, int $level): string|false

--- a/src/Compression/CompressionEncoder.php
+++ b/src/Compression/CompressionEncoder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Kirby\Cache\Compression;
+
+/**
+ * Interface for compression encoders used by StatiCache
+ * to write pre-compressed copies of cached files
+ *
+ * @package   Kirby Staticache
+ * @author    Tobias Möritz
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+interface CompressionEncoder
+{
+	/**
+	 * Returns the encoding name
+	 * (e.g. 'gzip', 'br', 'zstd')
+	 */
+	public function encoding(): string;
+
+	/**
+	 * Returns the file extension for compressed files
+	 * (e.g. 'gz', 'br', 'zst')
+	 */
+	public function extension(): string;
+
+	/**
+	 * Returns the default compression level
+	 */
+	public function defaultLevel(): int;
+
+	/**
+	 * Encodes the given content at the specified compression level
+	 *
+	 * @return string|false The compressed content or false on failure
+	 */
+	public function encode(string $content, int $level): string|false;
+}

--- a/src/Compression/GzipEncoder.php
+++ b/src/Compression/GzipEncoder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Kirby\Cache\Compression;
+
+/**
+ * Gzip compression encoder using PHP's built-in zlib
+ *
+ * @package   Kirby Staticache
+ * @author    Tobias Möritz
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class GzipEncoder implements CompressionEncoder
+{
+	public function encoding(): string
+	{
+		return 'gzip';
+	}
+
+	public function extension(): string
+	{
+		return 'gz';
+	}
+
+	public function defaultLevel(): int
+	{
+		return 6;
+	}
+
+	public function encode(string $content, int $level): string|false
+	{
+		return gzencode($content, $level);
+	}
+}

--- a/src/Compression/ZstdEncoder.php
+++ b/src/Compression/ZstdEncoder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Kirby\Cache\Compression;
+
+/**
+ * Zstandard compression encoder
+ *
+ * Requires the `zstd` PHP extension to be loaded.
+ *
+ * @package   Kirby Staticache
+ * @author    Tobias Möritz
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class ZstdEncoder implements CompressionEncoder
+{
+	public function encoding(): string
+	{
+		return 'zstd';
+	}
+
+	public function extension(): string
+	{
+		return 'zst';
+	}
+
+	public function defaultLevel(): int
+	{
+		return ZSTD_COMPRESS_LEVEL_DEFAULT;
+	}
+
+	public function encode(string $content, int $level): string|false
+	{
+		return zstd_compress($content, $level);
+	}
+}

--- a/src/StatiCache.php
+++ b/src/StatiCache.php
@@ -7,6 +7,10 @@ use Kirby\Cms\App;
 use Kirby\Cms\Url;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\Mime;
+use Kirby\Cache\Compression\BrotliEncoder;
+use Kirby\Cache\Compression\CompressionEncoder;
+use Kirby\Cache\Compression\GzipEncoder;
+use Kirby\Cache\Compression\ZstdEncoder;
 use Kirby\Toolkit\Str;
 
 /**
@@ -80,9 +84,8 @@ class StatiCache extends FileCache
 	{
 		$file = $this->file(static::parseCacheId($key));
 
-		foreach ($this->compressionConfig() as $encoding => $level) {
-			$ext = static::compressionExtension($encoding);
-			F::remove($file . '.' . $ext);
+		foreach ($this->compressionConfig() as ['encoder' => $encoder]) {
+			F::remove($file . '.' . $encoder->extension());
 		}
 
 		return parent::remove($key);
@@ -195,27 +198,47 @@ class StatiCache extends FileCache
 	 */
 	protected function writeCompressed(string $file, string $content): void
 	{
-		foreach ($this->compressionConfig() as $encoding => $level) {
-			$compressed = match ($encoding) {
-				'gzip' => gzencode($content, $level),
-				default => false
-			};
+		foreach ($this->compressionConfig() as ['encoder' => $encoder, 'level' => $level]) {
+			$compressed = $encoder->encode($content, $level);
 
 			if ($compressed !== false) {
-				$ext = static::compressionExtension($encoding);
-				F::write($file . '.' . $ext, $compressed);
+				F::write($file . '.' . $encoder->extension(), $compressed);
 			}
 		}
 	}
 
 	/**
-	 * Parses the `compression` option into a normalized
-	 * `['encoding' => level]` array
+	 * Returns the available compression encoders keyed by encoding name
+	 *
+	 * Only returns encoders whose PHP extensions are loaded.
+	 *
+	 * @return array<string, CompressionEncoder>
+	 */
+	protected static function encoders(): array
+	{
+		$encoders = [
+			'gzip' => new GzipEncoder(),
+		];
+
+		if (extension_loaded('brotli') === true) {
+			$encoders['br'] = new BrotliEncoder();
+		}
+
+		if (extension_loaded('zstd') === true) {
+			$encoders['zstd'] = new ZstdEncoder();
+		}
+
+		return $encoders;
+	}
+
+	/**
+	 * Parses the `compression` option into a normalized array
+	 * of encoder/level pairs
 	 *
 	 * Supports both `['gzip']` (default level) and
 	 * `['gzip' => 9]` (explicit level) syntax.
 	 *
-	 * @return array<string, int>
+	 * @return array<int, array{encoder: CompressionEncoder, level: int}>
 	 */
 	protected function compressionConfig(): array
 	{
@@ -225,40 +248,25 @@ class StatiCache extends FileCache
 			return [];
 		}
 
-		$result = [];
+		$encoders = static::encoders();
+		$result   = [];
 
 		foreach ($config as $key => $value) {
 			if (is_int($key) === true) {
-				// ['gzip'] syntax — use default level
-				$result[$value] = static::compressionDefaultLevel($value);
+				$encoding = $value;
+				$encoder  = $encoders[$encoding] ?? null;
+				$level    = $encoder?->defaultLevel();
 			} else {
-				// ['gzip' => 9] syntax
-				$result[$key] = $value;
+				$encoding = $key;
+				$encoder  = $encoders[$encoding] ?? null;
+				$level    = $value;
+			}
+
+			if ($encoder !== null) {
+				$result[] = ['encoder' => $encoder, 'level' => $level];
 			}
 		}
 
 		return $result;
-	}
-
-	/**
-	 * Returns the file extension for a compression encoding
-	 */
-	protected static function compressionExtension(string $encoding): string
-	{
-		return match ($encoding) {
-			'gzip' => 'gz',
-			default => $encoding
-		};
-	}
-
-	/**
-	 * Returns the default compression level for an encoding
-	 */
-	protected static function compressionDefaultLevel(string $encoding): int
-	{
-		return match ($encoding) {
-			'gzip' => 6,
-			default => -1
-		};
 	}
 }

--- a/src/StatiCache.php
+++ b/src/StatiCache.php
@@ -59,7 +59,33 @@ class StatiCache extends FileCache
 			$result  = $headers . "\n\n" . $result;
 		}
 
-		return F::write($this->file($cacheId), $result);
+		$file    = $this->file($cacheId);
+		$success = F::write($file, $result);
+
+		if ($success === true) {
+			$this->writeCompressed($file, $result);
+		}
+
+		return $success;
+	}
+
+	/**
+	 * Removes an item from the cache and
+	 * returns whether the operation was successful
+	 *
+	 * Overrides the parent to also remove compressed
+	 * copies that the parent doesn't know about.
+	 */
+	public function remove(string $key): bool
+	{
+		$file = $this->file(static::parseCacheId($key));
+
+		foreach ($this->compressionConfig() as $encoding => $level) {
+			$ext = static::compressionExtension($encoding);
+			F::remove($file . '.' . $ext);
+		}
+
+		return parent::remove($key);
 	}
 
 	/**
@@ -161,5 +187,78 @@ class StatiCache extends FileCache
 		$id       = implode('.', $parts);
 
 		return compact('id', 'language', 'contentType', 'version');
+	}
+
+	/**
+	 * Writes compressed copies of a cached file for each
+	 * configured compression encoding
+	 */
+	protected function writeCompressed(string $file, string $content): void
+	{
+		foreach ($this->compressionConfig() as $encoding => $level) {
+			$compressed = match ($encoding) {
+				'gzip' => gzencode($content, $level),
+				default => false
+			};
+
+			if ($compressed !== false) {
+				$ext = static::compressionExtension($encoding);
+				F::write($file . '.' . $ext, $compressed);
+			}
+		}
+	}
+
+	/**
+	 * Parses the `compression` option into a normalized
+	 * `['encoding' => level]` array
+	 *
+	 * Supports both `['gzip']` (default level) and
+	 * `['gzip' => 9]` (explicit level) syntax.
+	 *
+	 * @return array<string, int>
+	 */
+	protected function compressionConfig(): array
+	{
+		$config = $this->options['compression'] ?? [];
+
+		if (is_array($config) === false) {
+			return [];
+		}
+
+		$result = [];
+
+		foreach ($config as $key => $value) {
+			if (is_int($key) === true) {
+				// ['gzip'] syntax — use default level
+				$result[$value] = static::compressionDefaultLevel($value);
+			} else {
+				// ['gzip' => 9] syntax
+				$result[$key] = $value;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Returns the file extension for a compression encoding
+	 */
+	protected static function compressionExtension(string $encoding): string
+	{
+		return match ($encoding) {
+			'gzip' => 'gz',
+			default => $encoding
+		};
+	}
+
+	/**
+	 * Returns the default compression level for an encoding
+	 */
+	protected static function compressionDefaultLevel(string $encoding): int
+	{
+		return match ($encoding) {
+			'gzip' => 6,
+			default => -1
+		};
 	}
 }


### PR DESCRIPTION
## Description
Adds a `compression` option that writes pre-compressed copies of cached files alongside the originals, allowing the web server to serve them directly without runtime compression overhead.

Supports `['gzip']` (default level 6) and `['gzip' => 9]` (explicit level) syntax. The array format allows adding more encodings in the future (e.g. brotli, zstd) once they land in PHP core.

AI Disclosure: This PR was written with Claude Opus 4.6.

### Reasoning

Runtime compression adds latency to every request. Since Staticache already writes static files to disk, writing a pre-compressed copy at cache time is essentially free. This speed up Apache requests about 2-3x compared to on-demand `mod_deflate` for my setups.

### Additional context

Configuration example:
  
```php
  'cache' => [
    'pages' => [
      'active'      => true,
      'type'        => 'static',
      'compression' => ['gzip' => 9]
    ]
  ]
```
